### PR TITLE
Added additional check on method_exists() supporting php8.0

### DIFF
--- a/src/SceneTransformer.php
+++ b/src/SceneTransformer.php
@@ -535,7 +535,7 @@ abstract class SceneTransformer implements Transformer
         }
 
         // 3. Call get method on object
-        if ((is_object($original) || is_string($original)) && method_exists($original, $getMethod)) {
+        if (is_object($original) && method_exists($original, $getMethod)) {
             return call_user_func_array([$original, $getMethod], []);
         }
 

--- a/src/SceneTransformer.php
+++ b/src/SceneTransformer.php
@@ -535,7 +535,7 @@ abstract class SceneTransformer implements Transformer
         }
 
         // 3. Call get method on object
-        if (method_exists($original, $getMethod)) {
+        if ((is_object($original) || is_string($original)) && method_exists($original, $getMethod)) {
             return call_user_func_array([$original, $getMethod], []);
         }
 


### PR DESCRIPTION
Method `method_exists('ObjectOrClassName', 'methodName)` earlier not used to throw an error if we pass anything to first param instead of **Object or Class name as string**. In PHP8.0 function throws an `TypeError` exception.

Here is the test evaluating same on major PHP version https://3v4l.org/pRbos